### PR TITLE
DM-32544: remove failing attempts to extract metrics from rc2_subset repos

### DIFF
--- a/bin/measureHscRC2Metrics.sh
+++ b/bin/measureHscRC2Metrics.sh
@@ -12,6 +12,7 @@ pipetask --long-log run -j $NUMPROC -b ${RC2_SUBSET_DIR}/SMALL_HSC/butler.yaml -
 
 pipetask --long-log run -j $NUMPROC -b ${RC2_SUBSET_DIR}/SMALL_HSC/butler.yaml -p ${RC2_SUBSET_DIR}'/pipelines/DRP.yaml#nightlyStep5' -d "tract = 9813 and skymap = 'hsc_rings_v1' AND patch in (40)" -i jenkins/step4 --register-dataset-types -o jenkins/step5
 
+${FARO_DIR}/bin/make_job_document.py ${RC2_SUBSET_DIR}/SMALL_HSC jenkins/step2
 ${FARO_DIR}/bin/make_job_document.py ${RC2_SUBSET_DIR}/SMALL_HSC jenkins/step3
 ${FARO_DIR}/bin/make_job_document.py ${RC2_SUBSET_DIR}/SMALL_HSC jenkins/step5
 ${FARO_DIR}/bin/make_job_document.py ${RC2_SUBSET_DIR}/SMALL_HSC jenkins/step5 --metrics_package "pipe_analysis"

--- a/bin/measureHscRC2Metrics.sh
+++ b/bin/measureHscRC2Metrics.sh
@@ -12,7 +12,6 @@ pipetask --long-log run -j $NUMPROC -b ${RC2_SUBSET_DIR}/SMALL_HSC/butler.yaml -
 
 pipetask --long-log run -j $NUMPROC -b ${RC2_SUBSET_DIR}/SMALL_HSC/butler.yaml -p ${RC2_SUBSET_DIR}'/pipelines/DRP.yaml#nightlyStep5' -d "tract = 9813 and skymap = 'hsc_rings_v1' AND patch in (40)" -i jenkins/step4 --register-dataset-types -o jenkins/step5
 
-${FARO_DIR}/bin/make_job_document.py ${RC2_SUBSET_DIR}/SMALL_HSC jenkins/step2
 ${FARO_DIR}/bin/make_job_document.py ${RC2_SUBSET_DIR}/SMALL_HSC jenkins/step3
 ${FARO_DIR}/bin/make_job_document.py ${RC2_SUBSET_DIR}/SMALL_HSC jenkins/step3 --metrics_package "pipe_analysis"
 ${FARO_DIR}/bin/make_job_document.py ${RC2_SUBSET_DIR}/SMALL_HSC jenkins/step5

--- a/bin/measureHscRC2Metrics.sh
+++ b/bin/measureHscRC2Metrics.sh
@@ -12,7 +12,6 @@ pipetask --long-log run -j $NUMPROC -b ${RC2_SUBSET_DIR}/SMALL_HSC/butler.yaml -
 
 pipetask --long-log run -j $NUMPROC -b ${RC2_SUBSET_DIR}/SMALL_HSC/butler.yaml -p ${RC2_SUBSET_DIR}'/pipelines/DRP.yaml#nightlyStep5' -d "tract = 9813 and skymap = 'hsc_rings_v1' AND patch in (40)" -i jenkins/step4 --register-dataset-types -o jenkins/step5
 
-${FARO_DIR}/bin/make_job_document.py ${RC2_SUBSET_DIR}/SMALL_HSC jenkins/step2
 ${FARO_DIR}/bin/make_job_document.py ${RC2_SUBSET_DIR}/SMALL_HSC jenkins/step3
 ${FARO_DIR}/bin/make_job_document.py ${RC2_SUBSET_DIR}/SMALL_HSC jenkins/step5
 ${FARO_DIR}/bin/make_job_document.py ${RC2_SUBSET_DIR}/SMALL_HSC jenkins/step5 --metrics_package "pipe_analysis"

--- a/bin/measureHscRC2Metrics.sh
+++ b/bin/measureHscRC2Metrics.sh
@@ -13,6 +13,5 @@ pipetask --long-log run -j $NUMPROC -b ${RC2_SUBSET_DIR}/SMALL_HSC/butler.yaml -
 pipetask --long-log run -j $NUMPROC -b ${RC2_SUBSET_DIR}/SMALL_HSC/butler.yaml -p ${RC2_SUBSET_DIR}'/pipelines/DRP.yaml#nightlyStep5' -d "tract = 9813 and skymap = 'hsc_rings_v1' AND patch in (40)" -i jenkins/step4 --register-dataset-types -o jenkins/step5
 
 ${FARO_DIR}/bin/make_job_document.py ${RC2_SUBSET_DIR}/SMALL_HSC jenkins/step3
-${FARO_DIR}/bin/make_job_document.py ${RC2_SUBSET_DIR}/SMALL_HSC jenkins/step3 --metrics_package "pipe_analysis"
 ${FARO_DIR}/bin/make_job_document.py ${RC2_SUBSET_DIR}/SMALL_HSC jenkins/step5
 ${FARO_DIR}/bin/make_job_document.py ${RC2_SUBSET_DIR}/SMALL_HSC jenkins/step5 --metrics_package "pipe_analysis"


### PR DESCRIPTION
Ttwo changes:
1. Remove the line that calls make_job_document.py to extract metrics from "step2" repository. TE3/TE4 are improperly defined in verify_metrics, and this causes an error 
2. While testing this, I realized that the line to extract "pipe_analysis" metrics from "step3" is unnecessary (and fails). Remove that as well. (It was a mistake on my part to include that in the first place.)
