### PR TITLE
DM-33161: Missing metrics from verify_drp_metrics dashboard

### DIFF
--- a/pipelines/DRP.yaml
+++ b/pipelines/DRP.yaml
@@ -11,182 +11,182 @@ tasks:
     config:
       connections.package: validate_drp
       connections.metric: PA1
+      measure.brightSnrMin: 100.0
+      measure.nMinPhotRepeat: 20
       python: |
         from lsst.faro.measurement import PA1Task
         config.measure.retarget(PA1Task)
-        config.measure.brightSnrMin = 100.0
-        config.measure.nMinPhotRepeat = 20
   PF1_design:
     class: lsst.faro.measurement.TractMatchedMeasurementTask
     config:
       connections.package: validate_drp
       connections.metric: PF1_design_gri
+      measure.threshPA2: 15.0
+      measure.brightSnrMin: 100.0
+      measure.nMinPhotRepeat: 20
       python: |
         from lsst.faro.measurement import PF1Task
         config.measure.retarget(PF1Task)
-        config.measure.threshPA2 = 15.0
-        config.measure.brightSnrMin = 100.0
-        config.measure.nMinPhotRepeat = 20
   modelPhotRepGal1:
     class: lsst.faro.measurement.TractMatchedMeasurementTask
     config:
       connections.package: validate_drp
       connections.metric: modelPhotRepGal1
+      measure.index: 1
+      measure.selectExtended: True
+      measure.selectSnrMin: 5
+      measure.selectSnrMax: 10
+      measure.nMinPhotRepeat: 20
       python: |
         from lsst.faro.measurement import ModelPhotRepTask
         config.measure.retarget(ModelPhotRepTask)
-        config.measure.index = 1
-        config.measure.selectExtended = True
-        config.measure.selectSnrMin = 5
-        config.measure.selectSnrMax = 10
-        config.measure.nMinPhotRepeat = 20
   modelPhotRepGal2:
     class: lsst.faro.measurement.TractMatchedMeasurementTask
     config:
       connections.package: validate_drp
       connections.metric: modelPhotRepGal2
+      measure.index: 2
+      measure.selectExtended: True
+      measure.selectSnrMin: 10
+      measure.selectSnrMax: 20
+      measure.nMinPhotRepeat: 20
       python: |
         from lsst.faro.measurement import ModelPhotRepTask
         config.measure.retarget(ModelPhotRepTask)
-        config.measure.index = 2
-        config.measure.selectExtended = True
-        config.measure.selectSnrMin = 10
-        config.measure.selectSnrMax = 20
-        config.measure.nMinPhotRepeat = 20
   modelPhotRepGal3:
     class: lsst.faro.measurement.TractMatchedMeasurementTask
     config:
       connections.package: validate_drp
       connections.metric: modelPhotRepGal3
+      measure.index: 3
+      measure.selectExtended: True
+      measure.selectSnrMin: 20
+      measure.selectSnrMax: 40
+      measure.nMinPhotRepeat: 20
       python: |
         from lsst.faro.measurement import ModelPhotRepTask
         config.measure.retarget(ModelPhotRepTask)
-        config.measure.index = 3
-        config.measure.selectExtended = True
-        config.measure.selectSnrMin = 20
-        config.measure.selectSnrMax = 40
-        config.measure.nMinPhotRepeat = 20
   modelPhotRepGal4:
     class: lsst.faro.measurement.TractMatchedMeasurementTask
     config:
       connections.package: validate_drp
       connections.metric: modelPhotRepGal4
+      measure.index: 4
+      measure.selectExtended: True
+      measure.selectSnrMin: 40
+      measure.selectSnrMax: 80
+      measure.nMinPhotRepeat: 20
       python: |
         from lsst.faro.measurement import ModelPhotRepTask
         config.measure.retarget(ModelPhotRepTask)
-        config.measure.index = 4
-        config.measure.selectExtended = True
-        config.measure.selectSnrMin = 40
-        config.measure.selectSnrMax = 80
-        config.measure.nMinPhotRepeat = 20
   modelPhotRepStar1:
     class: lsst.faro.measurement.TractMatchedMeasurementTask
     config:
       connections.package: validate_drp
       connections.metric: modelPhotRepStar1
+      measure.index: 1
+      measure.selectExtended: False
+      measure.selectSnrMin: 5
+      measure.selectSnrMax: 10
+      measure.nMinPhotRepeat: 20
       python: |
         from lsst.faro.measurement import ModelPhotRepTask
         config.measure.retarget(ModelPhotRepTask)
-        config.measure.index = 1
-        config.measure.selectExtended = False
-        config.measure.selectSnrMin = 5
-        config.measure.selectSnrMax = 10
-        config.measure.nMinPhotRepeat = 20
   modelPhotRepStar2:
     class: lsst.faro.measurement.TractMatchedMeasurementTask
     config:
       connections.package: validate_drp
       connections.metric: modelPhotRepStar2
+      measure.index: 2
+      measure.selectExtended: False
+      measure.selectSnrMin: 10
+      measure.selectSnrMax: 20
+      measure.nMinPhotRepeat: 20
       python: |
         from lsst.faro.measurement import ModelPhotRepTask
         config.measure.retarget(ModelPhotRepTask)
-        config.measure.index = 2
-        config.measure.selectExtended = False
-        config.measure.selectSnrMin = 10
-        config.measure.selectSnrMax = 20
-        config.measure.nMinPhotRepeat = 20
   modelPhotRepStar3:
     class: lsst.faro.measurement.TractMatchedMeasurementTask
     config:
       connections.package: validate_drp
       connections.metric: modelPhotRepStar3
+      measure.index: 3
+      measure.selectExtended: False
+      measure.selectSnrMin: 20
+      measure.selectSnrMax: 40
+      measure.nMinPhotRepeat: 20
       python: |
         from lsst.faro.measurement import ModelPhotRepTask
         config.measure.retarget(ModelPhotRepTask)
-        config.measure.index = 3
-        config.measure.selectExtended = False
-        config.measure.selectSnrMin = 20
-        config.measure.selectSnrMax = 40
-        config.measure.nMinPhotRepeat = 20
   modelPhotRepStar4:
     class: lsst.faro.measurement.TractMatchedMeasurementTask
     config:
       connections.package: validate_drp
       connections.metric: modelPhotRepStar4
+      measure.index: 4
+      measure.selectExtended: False
+      measure.selectSnrMin: 40
+      measure.selectSnrMax: 80
+      measure.nMinPhotRepeat: 20
       python: |
         from lsst.faro.measurement import ModelPhotRepTask
         config.measure.retarget(ModelPhotRepTask)
-        config.measure.index = 4
-        config.measure.selectExtended = False
-        config.measure.selectSnrMin = 40
-        config.measure.selectSnrMax = 80
-        config.measure.nMinPhotRepeat = 20
   psfPhotRepStar1:
     class: lsst.faro.measurement.TractMatchedMeasurementTask
     config:
       connections.package: validate_drp
       connections.metric: psfPhotRepStar1
+      measure.index: 1
+      measure.selectExtended: False
+      measure.selectSnrMin: 5
+      measure.selectSnrMax: 10
+      measure.magName: "slot_PsfFlux_mag"
+      measure.nMinPhotRepeat: 20
       python: |
         from lsst.faro.measurement import ModelPhotRepTask
         config.measure.retarget(ModelPhotRepTask)
-        config.measure.index = 1
-        config.measure.selectExtended = False
-        config.measure.selectSnrMin = 5
-        config.measure.selectSnrMax = 10
-        config.measure.magName = "slot_PsfFlux_mag"
-        config.measure.nMinPhotRepeat = 20
   psfPhotRepStar2:
     class: lsst.faro.measurement.TractMatchedMeasurementTask
     config:
       connections.package: validate_drp
       connections.metric: psfPhotRepStar2
+      measure.index: 2
+      measure.selectExtended: False
+      measure.selectSnrMin: 10
+      measure.selectSnrMax: 20
+      measure.magName: "slot_PsfFlux_mag"
+      measure.nMinPhotRepeat: 20
       python: |
         from lsst.faro.measurement import ModelPhotRepTask
         config.measure.retarget(ModelPhotRepTask)
-        config.measure.index = 2
-        config.measure.selectExtended = False
-        config.measure.selectSnrMin = 10
-        config.measure.selectSnrMax = 20
-        config.measure.magName = "slot_PsfFlux_mag"
-        config.measure.nMinPhotRepeat = 20
   psfPhotRepStar3:
     class: lsst.faro.measurement.TractMatchedMeasurementTask
     config:
       connections.package: validate_drp
       connections.metric: psfPhotRepStar3
+      measure.index: 3
+      measure.selectExtended: False
+      measure.selectSnrMin: 20
+      measure.selectSnrMax: 40
+      measure.magName: "slot_PsfFlux_mag"
+      measure.nMinPhotRepeat: 20
       python: |
         from lsst.faro.measurement import ModelPhotRepTask
         config.measure.retarget(ModelPhotRepTask)
-        config.measure.index = 3
-        config.measure.selectExtended = False
-        config.measure.selectSnrMin = 20
-        config.measure.selectSnrMax = 40
-        config.measure.magName = "slot_PsfFlux_mag"
-        config.measure.nMinPhotRepeat = 20
   psfPhotRepStar4:
     class: lsst.faro.measurement.TractMatchedMeasurementTask
     config:
       connections.package: validate_drp
       connections.metric: psfPhotRepStar4
+      measure.index: 4
+      measure.selectExtended: False
+      measure.selectSnrMin: 40
+      measure.selectSnrMax: 80
+      measure.magName: "slot_PsfFlux_mag"
+      measure.nMinPhotRepeat: 20
       python: |
         from lsst.faro.measurement import ModelPhotRepTask
         config.measure.retarget(ModelPhotRepTask)
-        config.measure.index = 4
-        config.measure.selectExtended = False
-        config.measure.selectSnrMin = 40
-        config.measure.selectSnrMax = 80
-        config.measure.magName = "slot_PsfFlux_mag"
-        config.measure.nMinPhotRepeat = 20
 subsets:
   fgcm:
     subset:

--- a/pipelines/DRP.yaml
+++ b/pipelines/DRP.yaml
@@ -6,6 +6,187 @@ tasks:
     class: lsst.pipe.tasks.multiBand.DetectCoaddSourcesTask
     config:
       detection.thresholdValue: 250
+  PA1:
+    class: lsst.faro.measurement.TractMatchedMeasurementTask
+    config:
+      connections.package: validate_drp
+      connections.metric: PA1
+      python: |
+        from lsst.faro.measurement import PA1Task
+        config.measure.retarget(PA1Task)
+        config.measure.brightSnrMin = 100.0
+        config.measure.nMinPhotRepeat = 20
+  PF1_design:
+    class: lsst.faro.measurement.TractMatchedMeasurementTask
+    config:
+      connections.package: validate_drp
+      connections.metric: PF1_design_gri
+      python: |
+        from lsst.faro.measurement import PF1Task
+        config.measure.retarget(PF1Task)
+        config.measure.threshPA2 = 15.0
+        config.measure.brightSnrMin = 100.0
+        config.measure.nMinPhotRepeat = 20
+  modelPhotRepGal1:
+    class: lsst.faro.measurement.TractMatchedMeasurementTask
+    config:
+      connections.package: validate_drp
+      connections.metric: modelPhotRepGal1
+      python: |
+        from lsst.faro.measurement import ModelPhotRepTask
+        config.measure.retarget(ModelPhotRepTask)
+        config.measure.index = 1
+        config.measure.selectExtended = True
+        config.measure.selectSnrMin = 5
+        config.measure.selectSnrMax = 10
+        config.measure.nMinPhotRepeat = 20
+  modelPhotRepGal2:
+    class: lsst.faro.measurement.TractMatchedMeasurementTask
+    config:
+      connections.package: validate_drp
+      connections.metric: modelPhotRepGal2
+      python: |
+        from lsst.faro.measurement import ModelPhotRepTask
+        config.measure.retarget(ModelPhotRepTask)
+        config.measure.index = 2
+        config.measure.selectExtended = True
+        config.measure.selectSnrMin = 10
+        config.measure.selectSnrMax = 20
+        config.measure.nMinPhotRepeat = 20
+  modelPhotRepGal3:
+    class: lsst.faro.measurement.TractMatchedMeasurementTask
+    config:
+      connections.package: validate_drp
+      connections.metric: modelPhotRepGal3
+      python: |
+        from lsst.faro.measurement import ModelPhotRepTask
+        config.measure.retarget(ModelPhotRepTask)
+        config.measure.index = 3
+        config.measure.selectExtended = True
+        config.measure.selectSnrMin = 20
+        config.measure.selectSnrMax = 40
+        config.measure.nMinPhotRepeat = 20
+  modelPhotRepGal4:
+    class: lsst.faro.measurement.TractMatchedMeasurementTask
+    config:
+      connections.package: validate_drp
+      connections.metric: modelPhotRepGal4
+      python: |
+        from lsst.faro.measurement import ModelPhotRepTask
+        config.measure.retarget(ModelPhotRepTask)
+        config.measure.index = 4
+        config.measure.selectExtended = True
+        config.measure.selectSnrMin = 40
+        config.measure.selectSnrMax = 80
+        config.measure.nMinPhotRepeat = 20
+  modelPhotRepStar1:
+    class: lsst.faro.measurement.TractMatchedMeasurementTask
+    config:
+      connections.package: validate_drp
+      connections.metric: modelPhotRepStar1
+      python: |
+        from lsst.faro.measurement import ModelPhotRepTask
+        config.measure.retarget(ModelPhotRepTask)
+        config.measure.index = 1
+        config.measure.selectExtended = False
+        config.measure.selectSnrMin = 5
+        config.measure.selectSnrMax = 10
+        config.measure.nMinPhotRepeat = 20
+  modelPhotRepStar2:
+    class: lsst.faro.measurement.TractMatchedMeasurementTask
+    config:
+      connections.package: validate_drp
+      connections.metric: modelPhotRepStar2
+      python: |
+        from lsst.faro.measurement import ModelPhotRepTask
+        config.measure.retarget(ModelPhotRepTask)
+        config.measure.index = 2
+        config.measure.selectExtended = False
+        config.measure.selectSnrMin = 10
+        config.measure.selectSnrMax = 20
+        config.measure.nMinPhotRepeat = 20
+  modelPhotRepStar3:
+    class: lsst.faro.measurement.TractMatchedMeasurementTask
+    config:
+      connections.package: validate_drp
+      connections.metric: modelPhotRepStar3
+      python: |
+        from lsst.faro.measurement import ModelPhotRepTask
+        config.measure.retarget(ModelPhotRepTask)
+        config.measure.index = 3
+        config.measure.selectExtended = False
+        config.measure.selectSnrMin = 20
+        config.measure.selectSnrMax = 40
+        config.measure.nMinPhotRepeat = 20
+  modelPhotRepStar4:
+    class: lsst.faro.measurement.TractMatchedMeasurementTask
+    config:
+      connections.package: validate_drp
+      connections.metric: modelPhotRepStar4
+      python: |
+        from lsst.faro.measurement import ModelPhotRepTask
+        config.measure.retarget(ModelPhotRepTask)
+        config.measure.index = 4
+        config.measure.selectExtended = False
+        config.measure.selectSnrMin = 40
+        config.measure.selectSnrMax = 80
+        config.measure.nMinPhotRepeat = 20
+  psfPhotRepStar1:
+    class: lsst.faro.measurement.TractMatchedMeasurementTask
+    config:
+      connections.package: validate_drp
+      connections.metric: psfPhotRepStar1
+      python: |
+        from lsst.faro.measurement import ModelPhotRepTask
+        config.measure.retarget(ModelPhotRepTask)
+        config.measure.index = 1
+        config.measure.selectExtended = False
+        config.measure.selectSnrMin = 5
+        config.measure.selectSnrMax = 10
+        config.measure.magName = "slot_PsfFlux_mag"
+        config.measure.nMinPhotRepeat = 20
+  psfPhotRepStar2:
+    class: lsst.faro.measurement.TractMatchedMeasurementTask
+    config:
+      connections.package: validate_drp
+      connections.metric: psfPhotRepStar2
+      python: |
+        from lsst.faro.measurement import ModelPhotRepTask
+        config.measure.retarget(ModelPhotRepTask)
+        config.measure.index = 2
+        config.measure.selectExtended = False
+        config.measure.selectSnrMin = 10
+        config.measure.selectSnrMax = 20
+        config.measure.magName = "slot_PsfFlux_mag"
+        config.measure.nMinPhotRepeat = 20
+  psfPhotRepStar3:
+    class: lsst.faro.measurement.TractMatchedMeasurementTask
+    config:
+      connections.package: validate_drp
+      connections.metric: psfPhotRepStar3
+      python: |
+        from lsst.faro.measurement import ModelPhotRepTask
+        config.measure.retarget(ModelPhotRepTask)
+        config.measure.index = 3
+        config.measure.selectExtended = False
+        config.measure.selectSnrMin = 20
+        config.measure.selectSnrMax = 40
+        config.measure.magName = "slot_PsfFlux_mag"
+        config.measure.nMinPhotRepeat = 20
+  psfPhotRepStar4:
+    class: lsst.faro.measurement.TractMatchedMeasurementTask
+    config:
+      connections.package: validate_drp
+      connections.metric: psfPhotRepStar4
+      python: |
+        from lsst.faro.measurement import ModelPhotRepTask
+        config.measure.retarget(ModelPhotRepTask)
+        config.measure.index = 4
+        config.measure.selectExtended = False
+        config.measure.selectSnrMin = 40
+        config.measure.selectSnrMax = 80
+        config.measure.magName = "slot_PsfFlux_mag"
+        config.measure.nMinPhotRepeat = 20
 subsets:
   fgcm:
     subset:


### PR DESCRIPTION
The missing metrics were because there were too few measurements meeting the requirements for reporting. This ticket loosens up the requirements so we will have photometric repeatability metrics in all available bands.