### PR TITLE
DM-33959: Update step1/2 to match default HSC pipeline

### DIFF
--- a/bin/measureHscRC2Metrics.sh
+++ b/bin/measureHscRC2Metrics.sh
@@ -4,11 +4,19 @@ set -e
 
 pipetask --long-log run -j $NUMPROC -b ${RC2_SUBSET_DIR}/SMALL_HSC/butler.yaml -p ${RC2_SUBSET_DIR}'/pipelines/DRP.yaml#nightlyStep1' -i HSC/RC2/defaults --register-dataset-types -o jenkins/step1
 
-pipetask --long-log run -j $NUMPROC -b ${RC2_SUBSET_DIR}/SMALL_HSC/butler.yaml -p ${RC2_SUBSET_DIR}'/pipelines/DRP.yaml#nightlyStep2a' -i jenkins/step1 --register-dataset-types -o jenkins/step2a
+echo "Running step2a on all visits"
+pipetask --long-log run -j $NUMPROC -b ${RC2_SUBSET_DIR}/SMALL_HSC/butler.yaml -p ${RC2_SUBSET_DIR}'/pipelines/DRP.yaml#nightlyStep2a' -i jenkins/step1 --register-dataset-types -o jenkins/step2
 
-pipetask --long-log run -b ${RC2_SUBSET_DIR}/SMALL_HSC/butler.yaml -p ${RC2_SUBSET_DIR}'/pipelines/DRP.yaml#nightlyStep2b' -i jenkins/step2a --register-dataset-types -o jenkins/step2b
+echo "Running step2b on tract 9813"
+pipetask --long-log run -j $NUMPROC -b ${RC2_SUBSET_DIR}/SMALL_HSC/butler.yaml -p ${RC2_SUBSET_DIR}'/pipelines/DRP.yaml#nightlyStep2b'  -d "tract = 9813 and skymap = 'hsc_rings_v1'" --register-dataset-types -o jenkins/step2
 
-pipetask --long-log run -j $NUMPROC -b ${RC2_SUBSET_DIR}/SMALL_HSC/butler.yaml -p ${RC2_SUBSET_DIR}'/pipelines/DRP.yaml#nightlyStep3' -d "tract = 9813 and skymap = 'hsc_rings_v1' AND patch in (40)" -i jenkins/step2b --register-dataset-types -o jenkins/step3
+echo "Running step2c without multiprocessing"
+pipetask --long-log run -b ${RC2_SUBSET_DIR}/SMALL_HSC/butler.yaml -p ${RC2_SUBSET_DIR}'/pipelines/DRP.yaml#nightlyStep2c' --register-dataset-types -o jenkins/step2
+
+echo "Running step2d on all visits"
+pipetask --long-log run -j $NUMPROC -b ${RC2_SUBSET_DIR}/SMALL_HSC/butler.yaml -p ${RC2_SUBSET_DIR}'/pipelines/DRP.yaml#nightlyStep2d' --register-dataset-types -o jenkins/step2
+
+pipetask --long-log run -j $NUMPROC -b ${RC2_SUBSET_DIR}/SMALL_HSC/butler.yaml -p ${RC2_SUBSET_DIR}'/pipelines/DRP.yaml#nightlyStep3' -d "tract = 9813 and skymap = 'hsc_rings_v1' AND patch in (40)" -i jenkins/step2 --register-dataset-types -o jenkins/step3
 
 pipetask --long-log run -j $NUMPROC -b ${RC2_SUBSET_DIR}/SMALL_HSC/butler.yaml -p ${RC2_SUBSET_DIR}'/pipelines/DRP.yaml#nightlyStep4' -d "tract = 9813 and skymap = 'hsc_rings_v1' AND patch in (40)" -i jenkins/step3 --register-dataset-types -o jenkins/step4
 

--- a/pipelines/DRP.yaml
+++ b/pipelines/DRP.yaml
@@ -252,11 +252,6 @@ subsets:
       - consolidatePreSourceTable
       - consolidateVisitSummary
       - skyCorr
-      - isolatedStarAssociation
-      - finalizeCharacterization
-      - nsrcMeasVisit
-      - TE3
-      - TE4
     description: >
       Per-visit tasks that can be run together, but only after the 'step1'.
       These should never be run with 'tract' or 'patch' as part of the data ID
@@ -271,14 +266,35 @@ subsets:
       functionality.  It may be removed in the future.
   nightlyStep2b:
     subset:
+      - isolatedStarAssociation
+      - jointcal
+    description: >
+      Per-tract tasks.
+      jointcal should be run with explicit 'tract' constraints essentially all the
+      time, because otherwise quanta will be created for jobs with only partial
+      visit coverage.
+      isolatedStarAssociation can be run with or without 'tract' constraints.
+  nightlyStep2c:
+    subset:
       - fgcmBuildStarsTable
       - fgcmFitCycle
       - fgcmOutputProducts
     description: >
-      FGCM tasks that must be run with no pipetask multiprocessing.
+      FGCM tasks that must be run with no pipetask multiprocessing
+      and no data query
+  nightlyStep2d:
+    subset:
+      - finalizeCharacterization
+      - writeRecalibratedSourceTable
+      - transformSourceTable
+      - consolidateSourceTable
+      - nsrcMeasVisit
+      - TE3
+      - TE4
+    description: >
+      Per-visit tasks. These should never be run with tract constraints
   nightlyStep3:
     subset:
-      - jointcal
       - makeWarp
       - assembleCoadd
       - detection

--- a/pipelines/DRP.yaml
+++ b/pipelines/DRP.yaml
@@ -239,8 +239,8 @@ subsets:
       - isr
       - characterizeImage
       - calibrate
-      - writeSourceTable
-      - transformSourceTable
+      - writePreSourceTable
+      - transformPreSourceTable
     description: >
       Per-detector tasks that can be run together to start the DRP pipeline.
       These should never be run with 'tract' or 'patch' as part of the data ID
@@ -249,7 +249,7 @@ subsets:
       select partial visits that overlap that region.
   nightlyStep2a:
     subset:
-      - consolidateSourceTable
+      - consolidatePreSourceTable
       - consolidateVisitSummary
       - skyCorr
       - isolatedStarAssociation


### PR DESCRIPTION
wherein CalibrateTask produces PreSources.
Sources will be produced after global calibration.