### PR TITLE
DM-38498: Add band constraints to steps with faro tasks.

### DIFF
--- a/bin/measureHscRC2Metrics.sh
+++ b/bin/measureHscRC2Metrics.sh
@@ -28,7 +28,7 @@ echo "Running nightlyStep4 on tract 9813, patch 40"
 pipetask --long-log run --register-dataset-types -j $NUMPROC -b $REPO -i $OUTPUT_COLLECTION_STUB/step3 -o $OUTPUT_COLLECTION_STUB/step4 -p $RC2_SUBSET_PIPELINE#nightlyStep4 -d "skymap = 'hsc_rings_v1' AND tract = 9813 AND patch in (40)"
 
 echo "Running nightlyStep5 on tract 9813, patch 40"
-pipetask --long-log run --register-dataset-types -j $NUMPROC -b $REPO -i $OUTPUT_COLLECTION_STUB/step4 -o $OUTPUT_COLLECTION_STUB/step5 -p $RC2_SUBSET_PIPELINE#nightlyStep5 -d "skymap = 'hsc_rings_v1' AND tract = 9813 AND patch in (40)"
+pipetask --long-log run --register-dataset-types -j $NUMPROC -b $REPO -i $OUTPUT_COLLECTION_STUB/step4 -o $OUTPUT_COLLECTION_STUB/step5 -p $RC2_SUBSET_PIPELINE#nightlyStep5 -d "skymap = 'hsc_rings_v1' AND tract = 9813 AND patch in (40) AND band in ('g', 'r', 'i', 'z', 'y')"
 
 echo "Running make_job_document.py faro script"
 ${FARO_DIR}/bin/make_job_document.py $REPO $OUTPUT_COLLECTION_STUB/step3

--- a/bin/run_rc2_subset.sh
+++ b/bin/run_rc2_subset.sh
@@ -116,7 +116,7 @@ cmd_4="$PIPETASK_RUN#nightlyStep4 -j $RC2_SUBSET_PROC -d \"skymap = 'hsc_rings_v
 echo -e "\nRunning nightlyStep4 on tract 9813, patch 40\n$cmd_4"
 eval $cmd_4
 
-cmd_5="$PIPETASK_RUN#nightlyStep5 -j $RC2_SUBSET_PROC -d \"skymap = 'hsc_rings_v1' AND tract = 9813 AND patch in (40)\""
+cmd_5="$PIPETASK_RUN#nightlyStep5 -j $RC2_SUBSET_PROC -d \"skymap = 'hsc_rings_v1' AND tract = 9813 AND patch in (40) AND band in ('g', 'r', 'i', 'z', 'y')\""
 echo -e "\nRunning nightlyStep5 on tract 9813, patch 40\n$cmd_5"
 eval $cmd_5
 


### PR DESCRIPTION
When a task has band in its quantum dimensions but does not have band in the dimensions of any of its inputs, it will run over all bands known to any instrument unless those bands are constrained by the data query.  It was an accident of the old QG generation algorithm that this wasn't happening before (unrelated tasks in the same step were providing a band constraint, but the middleware now sees them as unrelated).